### PR TITLE
Add simple bulletin board

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -137,6 +137,11 @@
       "menuLabel": "About",
       "menuLink": "/about",
       "category": null
+    },
+    {
+      "menuLabel": "Board",
+      "menuLink": "/board",
+      "category": null
     }
   ],
   "filters": [

--- a/src/pages/board.js
+++ b/src/pages/board.js
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+
+import Layout from '../components/Layout/Layout';
+import Container from '../components/Container';
+import * as styles from './board.module.css';
+
+const BoardPage = () => {
+  const [posts, setPosts] = useState([]);
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('boardPosts');
+    if (stored) {
+      setPosts(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('boardPosts', JSON.stringify(posts));
+  }, [posts]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!message.trim()) {
+      return;
+    }
+    const newPost = {
+      name: name || 'Anonymous',
+      message,
+      date: new Date().toISOString(),
+    };
+    setPosts([newPost, ...posts]);
+    setMessage('');
+  };
+
+  return (
+    <Layout>
+      <Container size={'medium'}>
+        <h1>Bulletin Board</h1>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <textarea
+            placeholder="Message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+          <button type="submit">Post</button>
+        </form>
+        <ul className={styles.postList}>
+          {posts.map((post, index) => (
+            <li key={index} className={styles.post}>
+              <div className={styles.postHeader}>
+                <strong>{post.name}</strong> -
+                {` ${new Date(post.date).toLocaleString()}`}
+              </div>
+              <p>{post.message}</p>
+            </li>
+          ))}
+        </ul>
+      </Container>
+    </Layout>
+  );
+};
+
+export default BoardPage;

--- a/src/pages/board.module.css
+++ b/src/pages/board.module.css
@@ -1,0 +1,29 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.form input,
+.form textarea {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+}
+
+.postList {
+  list-style: none;
+  padding: 0;
+}
+
+.post {
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 0.5rem;
+}
+
+.postHeader {
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- create `/board` page for a simple bulletin board
- style the board page
- link to the board from the header navigation

## Testing
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d44a1d0448325826dacdf27cfe4a8